### PR TITLE
Add individual methods to generate corresponding Command object

### DIFF
--- a/src/main/java/command/AddToDoCommand.java
+++ b/src/main/java/command/AddToDoCommand.java
@@ -34,7 +34,7 @@ public class AddToDoCommand extends Command {
         StringBuilder sb = new StringBuilder();
 
         sb.append("Got it. I've added this task:\n");
-        sb.append("  " + task);
+        sb.append("  " + task + "\n");
         sb.append("Now you have " + tasklist.size() + " tasks in the list.\n");
 
         return sb.toString();

--- a/src/main/java/command/DeleteCommand.java
+++ b/src/main/java/command/DeleteCommand.java
@@ -37,7 +37,7 @@ public class DeleteCommand extends Command {
             Task task = tasklist.delete(index);
 
             sb.append("Noted. I've removed this task:\n");
-            sb.append("  " + task);
+            sb.append("  " + task + "\n");
             sb.append("Now you have " + tasklist.size() + " tasks in the list.\n");
 
         } catch (TaskListOutOfBoundsException e) {

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -19,6 +19,7 @@ import tasks.ToDoException;
  * Parses user input into executable commands.
  */
 public class Parser {
+
     /**
      * Parses the user input string and returns the corresponding Command object.
      *
@@ -27,114 +28,231 @@ public class Parser {
      * @throws OuiOuiBaguetteException If the command is invalid or any part of the parsing process fails.
      */
     public Command parseCommand(String cmd) throws OuiOuiBaguetteException {
-        if (cmd.equals("bye")) {
-            return new ByeCommand();
 
-        } else if (cmd.equals("list")) {
-            return new ListCommand();
+        Command cmdFound = null;
 
-        } else if (cmd.startsWith("mark")) {
-            // Parse command to get index of task
-            int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
-            return new MarkCommand(index);
+        // Find appropriate command
+        cmdFound = cmdFound == null ? parseIfByeCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfListCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfMarkCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfUnmarkCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfTodoCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfDeadlineCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfEventCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfDeleteCommand(cmd) : cmdFound;
+        cmdFound = cmdFound == null ? parseIfFindCommand(cmd) : cmdFound;
 
-        } else if (cmd.startsWith("unmark")) {
-            // Parse command to get index of task
-            int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
-            return new UnmarkCommand(index);
-
-        } else if (cmd.startsWith("todo")) {
-            // Add ToDo
-            if (cmd.length() <= ("todo ").length()) {
-                throw new ToDoException("The description of a todo cannot be empty.");
-            }
-
-            String desc = cmd.substring(("todo ").length());
-
-            return new AddToDoCommand(desc);
-
-        } else if (cmd.startsWith("deadline")) {
-            // Add Deadline
-            if (cmd.length() <= ("deadline ").length()) {
-                throw new DeadlineException("The description of a deadline cannot be empty.");
-            }
-
-            String descAndDate = cmd.substring(("deadline ").length());
-
-            // Check if format is correct
-            if (!descAndDate.contains(" /by ")) {
-                throw new DeadlineException("""
-                    The format entered is wrong.
-                    \t Please follow the format: deadline <description> /by <due date>""");
-            }
-
-            String desc = descAndDate.split(" /by ")[0];
-            // Check if there is a valid description
-            if (desc.length() == 0) {
-                throw new DeadlineException("The description of a deadline cannot be empty.");
-            }
-
-            // Check if there is a valid due date
-            if (descAndDate.split(" /by ").length < 2) {
-                throw new DeadlineException("The due date of a deadline cannot be empty.");
-            }
-            String date = descAndDate.split(" /by ")[1];
-
-            return new AddDeadlineCommand(desc, date);
-
-        } else if (cmd.startsWith("event")) {
-            // Add Event
-            if (cmd.length() <= ("event ").length()) {
-                throw new EventException("The description of a deadline cannot be empty.");
-            }
-
-            String descAndStartEnd = cmd.substring(("event ").length());
-            // Check if format is correct
-            if (!descAndStartEnd.contains(" /from ") || !descAndStartEnd.contains(" /to ")) {
-                throw new EventException("""
-                    The format entered is wrong.
-                    \t Please follow the format: event <description> /from <start> /to <end>""");
-            }
-
-            String desc = descAndStartEnd.split(" /from ")[0];
-            // Check if there is a valid description
-            if (desc.length() == 0) {
-                throw new EventException("The description of an event cannot be empty.");
-            }
-
-            // Check if there is a valid start
-            if (descAndStartEnd.indexOf("/from ") + ("/from ").length()
-                    >= descAndStartEnd.indexOf(" /to")) {
-                throw new EventException("The start of an event cannot be empty.");
-            }
-            String start = descAndStartEnd.substring(
-                    descAndStartEnd.indexOf("/from ") + ("/from ").length(),
-                    descAndStartEnd.indexOf(" /to"));
-
-            // Check if there is a valid end
-            if (descAndStartEnd.split(" /to ").length < 2) {
-                throw new EventException("The end of an event cannot be empty.");
-            }
-            String end = descAndStartEnd.split(" /to ")[1];
-
-            return new AddEventCommand(desc, start, end);
-
-        } else if (cmd.startsWith("delete")) {
-            // Parse command to get index of task
-            int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
-
-            return new DeleteCommand(index);
-
-        } else if (cmd.startsWith("find")) {
-            // Parse command to get keyword
-            String keyword = cmd.substring(("find ").length());
-
-            return new FindCommand(keyword);
-
-        } else {
+        if (cmdFound == null) {
             // Unknown command
             throw new UnknownCommandException();
         }
+
+        return cmdFound;
+    }
+
+    /**
+     * Parses the command if it is a bye command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return A ByeCommand object or null if the command does not match.
+     */
+    public Command parseIfByeCommand(String cmd) {
+        if (!cmd.equals("bye")) {
+            return null;
+        }
+
+        return new ByeCommand();
+    }
+
+    /**
+     * Parses the command if it is a list command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return A ListCommand object or null if the command does not match.
+     */
+    public Command parseIfListCommand(String cmd) {
+        if (!cmd.equals("list")) {
+            return null;
+        }
+
+        return new ListCommand();
+    }
+
+    /**
+     * Parses the command if it is a mark command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return A MarkCommand object or null if the command does not match.
+     */
+    public Command parseIfMarkCommand(String cmd) {
+        if (!cmd.startsWith("mark")) {
+            return null;
+        }
+
+        // Parse command to get the index of the task
+        int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
+        return new MarkCommand(index);
+    }
+
+    /**
+     * Parses the command if it is an unmark command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return An UnmarkCommand object or null if the command does not match.
+     */
+    public Command parseIfUnmarkCommand(String cmd) {
+        if (!cmd.startsWith("unmark")) {
+            return null;
+        }
+
+        // Parse command to get the index of the task
+        int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
+        return new UnmarkCommand(index);
+    }
+
+    /**
+     * Parses the command if it is a todo command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return An AddToDoCommand object or null if the command does not match.
+     * @throws ToDoException If the description of the to-do task is empty.
+     */
+    public Command parseIfTodoCommand(String cmd) throws ToDoException {
+        if (!cmd.startsWith("todo ")) {
+            return null;
+        }
+
+        // Add ToDo
+        if (cmd.length() <= ("todo ").length()) {
+            throw new ToDoException("The description of a todo cannot be empty.");
+        }
+
+        String desc = cmd.substring(("todo ").length());
+
+        return new AddToDoCommand(desc);
+    }
+
+    /**
+     * Parses the command if it is a deadline command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return An AddDeadlineCommand object or null if the command does not match.
+     * @throws DeadlineException If the description or due date of the deadline is invalid.
+     */
+    public Command parseIfDeadlineCommand(String cmd) throws DeadlineException {
+        if (!cmd.startsWith("deadline ")) {
+            return null;
+        }
+
+        // Add Deadline
+        if (cmd.length() <= ("deadline ").length()) {
+            throw new DeadlineException("The description of a deadline cannot be empty.");
+        }
+
+        String descAndDate = cmd.substring(("deadline ").length());
+
+        // Check if the format is correct
+        if (!descAndDate.contains(" /by ")) {
+            throw new DeadlineException("""
+                The format entered is wrong.
+                \t Please follow the format: deadline <description> /by <due date>""");
+        }
+
+        String desc = descAndDate.split(" /by ")[0];
+        // Check if there is a valid description
+        if (desc.length() == 0) {
+            throw new DeadlineException("The description of a deadline cannot be empty.");
+        }
+
+        // Check if there is a valid due date
+        if (descAndDate.split(" /by ").length < 2) {
+            throw new DeadlineException("The due date of a deadline cannot be empty.");
+        }
+        String date = descAndDate.split(" /by ")[1];
+
+        return new AddDeadlineCommand(desc, date);
+    }
+
+    /**
+     * Parses the command if it is an event command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return An AddEventCommand object or null if the command does not match.
+     * @throws EventException If the description, start date, or end date of the event is invalid.
+     */
+    public Command parseIfEventCommand(String cmd) throws EventException {
+        if (!cmd.startsWith("event")) {
+            return null;
+        }
+
+        // Add Event
+        if (cmd.length() <= ("event ").length()) {
+            throw new EventException("The description of a deadline cannot be empty.");
+        }
+
+        String descAndStartEnd = cmd.substring(("event ").length());
+        // Check if the format is correct
+        if (!descAndStartEnd.contains(" /from ") || !descAndStartEnd.contains(" /to ")) {
+            throw new EventException("""
+                The format entered is wrong.
+                \t Please follow the format: event <description> /from <start> /to <end>""");
+        }
+
+        String desc = descAndStartEnd.split(" /from ")[0];
+        // Check if there is a valid description
+        if (desc.length() == 0) {
+            throw new EventException("The description of an event cannot be empty.");
+        }
+
+        // Check if there is a valid start
+        if (descAndStartEnd.indexOf("/from ") + ("/from ").length()
+                >= descAndStartEnd.indexOf(" /to")) {
+            throw new EventException("The start of an event cannot be empty.");
+        }
+        String start = descAndStartEnd.substring(
+                descAndStartEnd.indexOf("/from ") + ("/from ").length(),
+                descAndStartEnd.indexOf(" /to"));
+
+        // Check if there is a valid end
+        if (descAndStartEnd.split(" /to ").length < 2) {
+            throw new EventException("The end of an event cannot be empty.");
+        }
+        String end = descAndStartEnd.split(" /to ")[1];
+
+        return new AddEventCommand(desc, start, end);
+    }
+
+    /**
+     * Parses the command if it is a delete command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return A DeleteCommand object or null if the command does not match.
+     */
+    public Command parseIfDeleteCommand(String cmd) {
+        if (!cmd.startsWith("delete ")) {
+            return null;
+        }
+
+        // Parse command to get the index of the task
+        int index = Integer.parseInt(cmd.split(" ")[1]) - 1;
+
+        return new DeleteCommand(index);
+    }
+
+    /**
+     * Parses the command if it is a find command.
+     *
+     * @param cmd The user input string representing the command.
+     * @return A FindCommand object or null if the command does not match.
+     */
+    public Command parseIfFindCommand(String cmd) {
+        if (!cmd.startsWith("find ")) {
+            return null;
+        }
+
+        // Parse command to get the keyword
+        String keyword = cmd.substring(("find ").length());
+
+        return new FindCommand(keyword);
     }
 }
-


### PR DESCRIPTION
Command string is parsed in a long chain of if-else in parseCommand method.

This does not follow SLAP, as it makes 1 method responsible for checking, parsing, and creating the relevant command object for all commands. This also makes the metho body very long.

Let's isolate parsing of command string and creation of Command object for each command to its own method.

This adheres more closely to SLAP.